### PR TITLE
fix: Use peaceiris/actions-gh-pages for branch-based deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,15 +8,9 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
-  build:
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,18 +35,9 @@ jobs:
         run: |
           mkdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary

Switch from artifact-based `deploy-pages` to branch-based approach using `peaceiris/actions-gh-pages`:

- Publishes to `gh-pages` branch (already initialized)
- Creates browseable branch with built docs
- Edit links in docs will point to `gh-pages` branch

## Settings Required

After merging, configure GitHub Pages:

1. **Settings → Pages → Build and deployment**
2. Source: **Deploy from a branch**
3. Branch: **gh-pages** / `/ (root)`

## Test plan

- [x] `gh-pages` branch initialized
- [ ] Merge this PR
- [ ] Configure Pages settings (deploy from branch)
- [ ] Verify docs deploy to https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)