### PR TITLE
chore: update all references for repository rename to f5xc-marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
   "version": "3.4.0",
   "description": "F5 Distributed Cloud automation plugins for network engineers and DevOps teams",
   "license": "MIT",
-  "homepage": "https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace",
-  "repository": "https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace",
+  "homepage": "https://github.com/robinmordasiewicz/f5xc-marketplace",
+  "repository": "https://github.com/robinmordasiewicz/f5xc-marketplace",
   "owner": {
     "name": "Robin Mordasiewicz",
     "url": "https://github.com/robinmordasiewicz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,13 +287,13 @@ jobs:
             echo ""
             echo '```bash'
             echo '# Add this marketplace to Claude Code'
-            echo '/plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace'
+            echo '/plugin marketplace add robinmordasiewicz/f5xc-marketplace'
             echo ''
             echo '# Install plugins'
             echo '/plugin install f5xc-console'
             echo '```'
             echo ""
-            REPO_URL="https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace"
+            REPO_URL="https://github.com/robinmordasiewicz/f5xc-marketplace"
             echo "**Full Changelog**: $REPO_URL/blob/main/CHANGELOG.md"
           } > release_notes.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ Add to your plugin's release workflow:
   uses: peter-evans/repository-dispatch@v3
   with:
     token: ${{ secrets.MARKETPLACE_DISPATCH_TOKEN }}
-    repository: robinmordasiewicz/f5-distributed-cloud-marketplace
+    repository: robinmordasiewicz/f5xc-marketplace
     event-type: plugin-release
     client-payload: '{"plugin": "f5xc-console", "version": "${{ env.VERSION }}"}'
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # F5 Distributed Cloud Plugin Marketplace
 
-[![Validate Marketplace](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/validate.yml)
-[![Release](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/release.yml/badge.svg)](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/release.yml)
-[![Documentation](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/docs.yml/badge.svg)](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/actions/workflows/docs.yml)
+[![Validate Marketplace](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/validate.yml)
+[![Release](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/release.yml/badge.svg)](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/release.yml)
+[![Documentation](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/docs.yml/badge.svg)](https://github.com/robinmordasiewicz/f5xc-marketplace/actions/workflows/docs.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A curated collection of Claude Code plugins for automating F5 Distributed Cloud (XC) operations.
@@ -11,7 +11,7 @@ A curated collection of Claude Code plugins for automating F5 Distributed Cloud 
 
 ```bash
 # 1. Add this marketplace (one time)
-/plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace
+/plugin marketplace add robinmordasiewicz/f5xc-marketplace
 
 # 2. Install a plugin
 /plugin install f5xc-console
@@ -22,12 +22,12 @@ A curated collection of Claude Code plugins for automating F5 Distributed Cloud 
 
 ## Documentation
 
-**[View Full Documentation](https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/)**
+**[View Full Documentation](https://robinmordasiewicz.github.io/f5xc-marketplace/)**
 
-- [Getting Started](https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/getting-started/)
-- [Available Plugins](https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/plugins/)
-- [Contributing](https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/contributing/)
-- [Troubleshooting](https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/troubleshooting/)
+- [Getting Started](https://robinmordasiewicz.github.io/f5xc-marketplace/getting-started/)
+- [Available Plugins](https://robinmordasiewicz.github.io/f5xc-marketplace/plugins/)
+- [Contributing](https://robinmordasiewicz.github.io/f5xc-marketplace/contributing/)
+- [Troubleshooting](https://robinmordasiewicz.github.io/f5xc-marketplace/troubleshooting/)
 
 ## Available Plugins
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,8 +43,8 @@ Your plugin repository must have a valid `.claude-plugin/plugin.json`:
 ### Step 2: Fork the Marketplace
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace
-cd f5-distributed-cloud-marketplace
+git clone https://github.com/robinmordasiewicz/f5xc-marketplace
+cd f5xc-marketplace
 ```
 
 ### Step 3: Add Your Plugin Entry
@@ -148,8 +148,8 @@ git commit -m "feat!: redesign command interface"
 ### Clone the Repository
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace
-cd f5-distributed-cloud-marketplace
+git clone https://github.com/robinmordasiewicz/f5xc-marketplace
+cd f5xc-marketplace
 ```
 
 ### Install Dependencies
@@ -193,7 +193,7 @@ python scripts/generate-plugin-docs.py
 
 ## Getting Help
 
-- :material-github: [Open an Issue](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues)
+- :material-github: [Open an Issue](https://github.com/robinmordasiewicz/f5xc-marketplace/issues)
 - :material-message: Start a Discussion
 
 ## License

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,13 +31,13 @@ Add this marketplace to your Claude Code installation:
 === "Interactive"
 
     ```
-    /plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace
+    /plugin marketplace add robinmordasiewicz/f5xc-marketplace
     ```
 
 === "CLI"
 
     ```bash
-    claude plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace
+    claude plugin marketplace add robinmordasiewicz/f5xc-marketplace
     ```
 
 Verify the marketplace is added:

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ natural language commands, and enterprise-grade security for network engineers a
 
     === "Step 1: Add Marketplace"
         ```bash
-        /plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace
+        /plugin marketplace add robinmordasiewicz/f5xc-marketplace
         ```
 
     === "Step 2: Install Plugin"
@@ -159,7 +159,7 @@ natural language commands, and enterprise-grade security for network engineers a
 
     Common issues and solutions for plugin and automation problems.
 
-- :material-github: [**GitHub Issues**](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues)
+- :material-github: [**GitHub Issues**](https://github.com/robinmordasiewicz/f5xc-marketplace/issues)
 
     Report bugs, request features, or ask questions.
 
@@ -176,6 +176,6 @@ natural language commands, and enterprise-grade security for network engineers a
 **Ready to automate your F5 Distributed Cloud workflows?**
 
 [Get Started :material-arrow-right:](getting-started.md){ .md-button .md-button--primary }
-[View on GitHub :material-github:](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace){ .md-button }
+[View on GitHub :material-github:](https://github.com/robinmordasiewicz/f5xc-marketplace){ .md-button }
 
 </div>

--- a/docs/plugin-automation.md
+++ b/docs/plugin-automation.md
@@ -25,7 +25,7 @@ To enable automatic sync when your plugin publishes a new release, add this step
   uses: peter-evans/repository-dispatch@v3
   with:
     token: ${{ secrets.MARKETPLACE_DISPATCH_TOKEN }}
-    repository: robinmordasiewicz/f5-distributed-cloud-marketplace
+    repository: robinmordasiewicz/f5xc-marketplace
     event-type: plugin-release
     client-payload: |
       {
@@ -49,7 +49,7 @@ The plugin repository needs a Personal Access Token (PAT) with `repo` scope that
 For better security, use a fine-grained PAT:
 
 1. Create at https://github.com/settings/personal-access-tokens
-2. Repository access: Select `robinmordasiewicz/f5-distributed-cloud-marketplace`
+2. Repository access: Select `robinmordasiewicz/f5xc-marketplace`
 3. Permissions: Contents (read/write)
 4. Add as secret in your plugin repository
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,8 +139,8 @@ Migration tooling for onboarding.
 
 Have an idea for a new plugin or feature? We'd love to hear it!
 
-1. Check [existing issues](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues) for similar requests
-2. [Open a new issue](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues/new) with your proposal
+1. Check [existing issues](https://github.com/robinmordasiewicz/f5xc-marketplace/issues) for similar requests
+2. [Open a new issue](https://github.com/robinmordasiewicz/f5xc-marketplace/issues/new) with your proposal
 3. Include use cases and expected behavior
 
 ## Contributing
@@ -149,5 +149,5 @@ Want to help build these plugins? See our [Contributing Guide](contributing.md) 
 
 ## Version History
 
-See the [Changelog](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/blob/main/CHANGELOG.md)
+See the [Changelog](https://github.com/robinmordasiewicz/f5xc-marketplace/blob/main/CHANGELOG.md)
 for detailed release notes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ Common issues and solutions for the F5 Distributed Cloud plugin marketplace.
 
 # Re-add if necessary
 /plugin marketplace remove f5-distributed-cloud
-/plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace
+/plugin marketplace add robinmordasiewicz/f5xc-marketplace
 ```
 
 ---
@@ -227,8 +227,8 @@ When reporting issues, include:
 
 ### Report an Issue
 
-1. Search [existing issues](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues)
-2. If not found, [create a new issue](https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace/issues/new)
+1. Search [existing issues](https://github.com/robinmordasiewicz/f5xc-marketplace/issues)
+2. If not found, [create a new issue](https://github.com/robinmordasiewicz/f5xc-marketplace/issues/new)
 3. Use the bug report template
 4. Include diagnostic information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: F5 Distributed Cloud Plugin Marketplace
-site_url: https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/
+site_url: https://robinmordasiewicz.github.io/f5xc-marketplace/
 site_description: A curated collection of Claude Code plugins for automating F5 Distributed Cloud operations
 site_author: Robin Mordasiewicz
 
-repo_name: robinmordasiewicz/f5-distributed-cloud-marketplace
-repo_url: https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace
+repo_name: robinmordasiewicz/f5xc-marketplace
+repo_url: https://github.com/robinmordasiewicz/f5xc-marketplace
 edit_uri: blob/gh-pages/docs/
 
 theme:
@@ -107,7 +107,7 @@ markdown_extensions:
   - pymdownx.magiclink:
       repo_url_shorthand: true
       user: robinmordasiewicz
-      repo: f5-distributed-cloud-marketplace
+      repo: f5xc-marketplace
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.snippets:

--- a/plugins.json
+++ b/plugins.json
@@ -4,7 +4,7 @@
   "registry": {
     "name": "f5-distributed-cloud",
     "description": "F5 Distributed Cloud plugin registry",
-    "homepage": "https://github.com/robinmordasiewicz/f5-distributed-cloud-marketplace"
+    "homepage": "https://github.com/robinmordasiewicz/f5xc-marketplace"
   },
   "plugins": {
     "f5xc-console": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "f5-distributed-cloud-marketplace"
+name = "f5xc-marketplace"
 version = "0.1.0"
 description = "F5 Distributed Cloud Plugin Marketplace for Claude Code"
 requires-python = ">=3.12"

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/schemas/marketplace.schema.json",
+  "$id": "https://robinmordasiewicz.github.io/f5xc-marketplace/schemas/marketplace.schema.json",
   "title": "Claude Code Marketplace",
   "description": "JSON Schema for Claude Code plugin marketplace configuration",
   "type": "object",

--- a/schemas/plugins.schema.json
+++ b/schemas/plugins.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://robinmordasiewicz.github.io/f5-distributed-cloud-marketplace/schemas/plugins.schema.json",
+  "$id": "https://robinmordasiewicz.github.io/f5xc-marketplace/schemas/plugins.schema.json",
   "title": "Plugin Registry Schema",
   "description": "JSON Schema for plugin registry with GitHub and npm support",
   "type": "object",

--- a/scripts/generate-plugin-docs.py
+++ b/scripts/generate-plugin-docs.py
@@ -520,7 +520,7 @@ def generate_index_page(plugins: list[ProcessedPlugin], marketplace: Marketplace
             "",
             "```bash",
             "# Add this marketplace",
-            "/plugin marketplace add robinmordasiewicz/f5-distributed-cloud-marketplace",
+            "/plugin marketplace add robinmordasiewicz/f5xc-marketplace",
             "",
             "# Install any plugin",
             "/plugin install <plugin-name>",


### PR DESCRIPTION
## Summary
- Updated all file references from `f5-distributed-cloud-marketplace` to `f5xc-marketplace`
- 16 files modified with consistent string replacements

## Files Changed
- Core configs: `pyproject.toml`, `mkdocs.yml`, `marketplace.json`, `plugins.json`
- Schemas: `marketplace.schema.json`, `plugins.schema.json`
- CI/CD: `.github/workflows/release.yml`
- Documentation: `README.md`, 6 docs files
- Scripts: `generate-plugin-docs.py`
- Changelog: `CHANGELOG.md`

## Test plan
- [x] All references to old name replaced
- [x] No orphaned references remain
- [x] Git remote updated to new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)