### PR TITLE
chore: update to MIT license with 2026 copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Robin Mordasiewicz
+Copyright (c) 2026 Robin Mordasiewicz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/generate-plugin-docs.py
+++ b/scripts/generate-plugin-docs.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 """Generate plugin documentation from marketplace.json and plugin.json metadata.
 
 This script:

--- a/scripts/plugin-manager.sh
+++ b/scripts/plugin-manager.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 #
 # Plugin Manager for F5 Distributed Cloud Marketplace
 # Registry-based plugin installation with GitHub and npm support

--- a/scripts/sync-npm-plugins.sh
+++ b/scripts/sync-npm-plugins.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 #
 # Sync plugins from npm registry
 # Updates plugins.json and marketplace.json with latest versions


### PR DESCRIPTION
## Summary

Updates licensing information across the project to reflect 2026 copyright year:
- Updates main LICENSE file copyright year from 2024 to 2026
- Adds MIT license headers to all shell scripts and Python scripts
- Ensures consistent licensing across the entire codebase

## Changes

- LICENSE: Updated copyright year
- scripts/generate-plugin-docs.py: Added MIT license header
- scripts/plugin-manager.sh: Added MIT license header  
- scripts/sync-npm-plugins.sh: Added MIT license header

Closes #42

🤖 Generated with Claude Code