### PR TITLE
fix: add concurrency group and stale branch cleanup to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -144,6 +148,9 @@ jobs:
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Delete stale release branch if it exists from a previous failed run
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
 
           # Create release branch
           git checkout -b "$BRANCH_NAME"


### PR DESCRIPTION
Closes #65

## Summary
- Add `concurrency: { group: release, cancel-in-progress: false }` to prevent parallel Release runs from colliding
- Delete stale `release/v*` branch before pushing, so failed previous runs don't block future releases

## Root cause
Every push to main triggers the Release workflow. When two pushes happen close together (e.g., governance sync + another commit), two Release runs start simultaneously. The second run fails with `git push` rejection because the first run already created the `release/vX.Y.Z` branch. Once a run fails mid-way, the stale branch persists and blocks all future Release runs for the same version.

## Test plan
- [ ] Verify the Release workflow succeeds on the next push to main
- [ ] Verify concurrent pushes don't cause failures (concurrency group serializes them)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>