### PR TITLE
fix: use REPO_ADMIN_TOKEN in release workflow to trigger required checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Get latest tag
         id: get_tag
@@ -199,7 +199,7 @@ jobs:
         if: steps.bump.outputs.skip != 'true'
         id: create_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.bump.outputs.new_version }}"
           BRANCH_NAME="${{ steps.create_branch.outputs.branch_name }}"
@@ -226,7 +226,7 @@ jobs:
       - name: Merge Pull Request
         if: steps.bump.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
           PR_NUMBER="${{ steps.create_pr.outputs.pr_number }}"
 
@@ -313,4 +313,4 @@ jobs:
           body_path: release_notes.md
           generate_release_notes: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
Closes #68

## Summary
- Replace `GITHUB_TOKEN` with `REPO_ADMIN_TOKEN` in checkout, PR creation, PR merge, and GitHub Release steps
- `GITHUB_TOKEN`-created events don't trigger other workflows (GitHub anti-recursion), so the required "Check linked issues" check never starts, and auto-merge waits forever until timeout

## Root cause
GitHub prevents workflow recursion by not triggering workflows from events created by `GITHUB_TOKEN`. The Release workflow creates a PR using `GITHUB_TOKEN`, so `require-linked-issue.yml` never triggers. Since "Check linked issues" is a required status check, auto-merge can never proceed.

## Test plan
- [ ] Verify Release workflow creates PR that triggers the "Check linked issues" workflow
- [ ] Verify the check passes (release branches now excluded from linked-issue requirement)
- [ ] Verify auto-merge proceeds and the release completes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>