### PR TITLE
fix: use REPO_ADMIN_TOKEN in plugin-sync workflow

### DIFF
--- a/.github/workflows/plugin-sync.yml
+++ b/.github/workflows/plugin-sync.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -80,7 +80,7 @@ jobs:
       - name: Create PR for plugin update
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

The plugin-sync workflow creates PRs using `GITHUB_TOKEN`, which doesn't trigger other workflows due to GitHub's anti-recursion policy. This means the "Check linked issues" required status check never starts, blocking auto-merge indefinitely.

## Changes

- Use `REPO_ADMIN_TOKEN` for the `actions/checkout` step so pushes trigger CI workflows
- Use `REPO_ADMIN_TOKEN` for `GH_TOKEN` in the PR creation step so the PR triggers required checks

Closes #75

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)