### PR TITLE
fix: correct MDX syntax in plugin-automation documentation

### DIFF
--- a/docs/plugin-automation.mdx
+++ b/docs/plugin-automation.mdx
@@ -45,7 +45,7 @@ Store tokens as repository secrets only. Never commit tokens to source control o
 
 The plugin repository needs a Personal Access Token (PAT) with `repo` scope and write access to the marketplace repository:
 
-1. Create a PAT at <https://github.com/settings/tokens>
+1. Create a PAT at https://github.com/settings/tokens
 2. Grant `repo` scope (for repository dispatch)
 3. Add as secret `MARKETPLACE_DISPATCH_TOKEN` in the plugin repository
 
@@ -53,7 +53,7 @@ The plugin repository needs a Personal Access Token (PAT) with `repo` scope and 
 
 For tighter scoping, use a fine-grained PAT:
 
-1. Create at <https://github.com/settings/personal-access-tokens>
+1. Create at https://github.com/settings/personal-access-tokens
 2. Repository access: Select `robinmordasiewicz/f5xc-marketplace`
 3. Permissions: Contents (read/write)
 4. Add as secret in the plugin repository


### PR DESCRIPTION
Closes #100

## Summary
Fix MDX parsing error in plugin-automation.mdx caused by bare URLs wrapped in angle brackets.

The error was: '@mdx-js/rollup Unexpected character / before local name'

Removed angle brackets from URLs since MDX requires special JSX handling for URLs in angle bracket syntax.

## Changes
- plugin-automation.mdx: Remove angle brackets from bare URLs